### PR TITLE
Add React component for mounting the input element.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": [["babel-preset-gatsby-package"]]
+  "presets": [["babel-preset-gatsby-package", { "browser": true }]]
 }

--- a/README.md
+++ b/README.md
@@ -53,9 +53,22 @@ module.exports = {
 }
 ```
 
-Note that your project will still be responsible for mounting the appropriate input tags and calling `stork.register()` in your project, but `gatsby-plugin-stork` _does_ take care of loading `stork.js` from the CDN.
+The search bar can be mounted using the `StorkInput` component:
 
-## Options
+```jsx
+import React from 'react';
+import { StorkInput } from 'gatsby-plugin-stork';
+
+export const YourSearchComponent => () => {
+  return (
+    <StorkInput filename="indexFile.st" placeholder="🔍" />
+  );
+}
+```
+
+If you want to load a [Stork Theme](https://stork-search.net/themes/), you will need to load the Stork CSS yourself.
+
+## Configuration Options
 
 ### `query`
 
@@ -84,15 +97,11 @@ Note that this project is still pre-1.0, and until it has some users, minor vers
 
 ## Future Development
 
-- [ ] Support all of the [configuration options](https://stork-search.net/docs/config-ref) for generating indices.
-
 - [ ] Support generating multiple named indices.
 
 - [ ] Support loading CSS from CDN
 
 - [ ] Add option for installing Stork during CI builds
-
-- [X] Add React input element with necessary configuration.
 
 - [ ] Create a Gatsby starter using the plugin
 

--- a/README.md
+++ b/README.md
@@ -88,9 +88,11 @@ Note that this project is still pre-1.0, and until it has some users, minor vers
 
 - [ ] Support generating multiple named indices.
 
+- [ ] Support loading CSS from CDN
+
 - [ ] Add option for installing Stork during CI builds
 
-- [ ] Add React input element with necessary configuration.
+- [X] Add React input element with necessary configuration.
 
 - [ ] Create a Gatsby starter using the plugin
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@ interface StorkInputProps {
   placeholder?: string;
 }
 
-export class OutboundLink extends React.Component<
+export class StorkInput extends React.Component<
   StorkInputProps & React.HTMLProps<HTMLInputElement>,
   any
 > {}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,12 @@
+import * as React from "react";
+
+interface StorkInputProps {
+  indexName?: string;
+  file?: string;
+  placeholder?: string;
+}
+
+export class OutboundLink extends React.Component<
+  StorkInputProps & React.HTMLProps<HTMLInputElement>,
+  any
+> {}

--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-// This file is a noop, but we need a "main" file, so ¯\_(ツ)_/¯

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A Gatsby plugin for generating Stork search indexes.",
   "license": "MIT",
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/reese/gatsby-plugin-stork.git"

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,29 @@
+import React from "react";
+
+/**
+ * This component mounts the necessary input elements that Stork hooks into.
+ * Based on the interface defined [here](https://stork-search.net/docs/interface) in the documentation.
+ */
+export const StorkInput = ({
+  /** The name of your search's input. This is the first argument of `stork.register`. */
+  indexName = "site",
+  /** The name of your index file. This is assumed to be served at `https://your-site.com/${file} */
+  file = "stork.st",
+  /** The placeholder for your search input. Empty by default. */
+  placeholder = "",
+}) => {
+  useEffect(() => {
+    window.stork.register(indexName, `${window.location.origin}/${file}`);
+  }, []);
+
+  return (
+    <div className="stork-wrapper">
+      <input
+        data-stork={indexName}
+        className="stork-input"
+        placeholder={placeholder}
+      />
+      <div data-stork={`${indexName}-output`} className="stork-output" />
+    </div>
+  );
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 
 /**
  * This component mounts the necessary input elements that Stork hooks into.
@@ -11,13 +11,15 @@ export const StorkInput = ({
   file = "stork.st",
   /** The placeholder for your search input. Empty by default. */
   placeholder = "",
+  className,
+  ...props
 }) => {
   useEffect(() => {
     window.stork.register(indexName, `${window.location.origin}/${file}`);
   }, []);
 
   return (
-    <div className="stork-wrapper">
+    <div className={`stork-wrapper ${className}`} {...props}>
       <input
         data-stork={indexName}
         className="stork-input"


### PR DESCRIPTION
Since Stork requires a particular [HTML interface](https://stork-search.net/docs/interface) to hook into, I think it'll be a good idea to pull all of that into its own component for downstream users to use. Along with eventual config changes to automatically load CSS, the goal is eventually for users to _never_ have to look at the Stork docs and can use this plugin as something more akin to an opaque wrapper.