### PR TITLE
Allow option to automatically fetch a Stork theme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ module.exports = {
             `,
             serialize: ({ allMdx }) => yourSerializationFunction(allMdx),
             filename: "indexFile.st",
+            theme: "dark"
         }
     ]
 }
@@ -89,6 +90,11 @@ By default, it is called `stork.st`, but you may wish to call it something else.
 The directory where the index will be stored.
 By default, it is stored in the `public` directory of your project.
 We do not recommend changing this unless you will be storing the index file somewhere else (such as your own external CDN).
+
+### `theme`
+
+The name of the [Stork theme](https://stork-search.net/themes) to install.
+Setting this option to `null` will not install a theme.
 
 ## Project Status
 

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -52,6 +52,7 @@ const DEFAULTS = {
   serialize: DEFAULT_SERIALIZER,
   filename: DEFAULT_OUTPUT_FILE_NAME,
   outputDir: DEFAULT_PUBLIC_PATH,
+  theme: "basic",
 };
 
 module.exports = { DEFAULTS };

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -51,6 +51,18 @@ exports.onPostBuild = async ({ graphql }, pluginOptions) => {
   const tomlString = TOML.stringify(outputObject);
   await fs.writeFile(tempFileName, tomlString);
 
+  assertStorkIsInstalled();
+  buildStorkIndex(tempFileName, tomlString);
+
+  // Clean up temp file
+  removeCallback();
+};
+
+/**
+ * Checks that stork is installed on the host machine.
+ * @throws if Stork is not present.
+ */
+function assertStorkIsInstalled() {
   // Check if Stork is present
   try {
     execSync("which -s stork"); // `-s` omits output and just returns a 0 or 1 exit code
@@ -60,8 +72,13 @@ exports.onPostBuild = async ({ graphql }, pluginOptions) => {
     );
     throw e;
   }
+}
 
-  // call `stork` on TOML file
+/**
+ * Builds stork index.
+ * @throws if Stork returns a non-zero exit code.
+ */
+function buildStorkIndex(tempFileName, tomlString) {
   try {
     execSync(`stork --build ${tempFileName}`);
   } catch (e) {
@@ -69,5 +86,4 @@ exports.onPostBuild = async ({ graphql }, pluginOptions) => {
     console.error(tomlString);
     throw e;
   }
-  removeCallback();
-};
+}

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -2,8 +2,20 @@
 
 const React = require("react");
 
-exports.onRenderBody = ({ setPostBodyComponents }) => {
+exports.onRenderBody = (
+  { setHeadComponents, setPostBodyComponents },
+  { theme }
+) => {
+  setHeadComponents([
+    theme === null ? null : (
+      <link
+        key="1"
+        rel="stylesheet"
+        href={`https://files.stork-search.net/${theme}.css`}
+      />
+    ),
+  ]);
   setPostBodyComponents([
-    <script src="https://files.stork-search.net/stork.js" />,
+    <script key="1" src="https://files.stork-search.net/stork.js" />,
   ]);
 };

--- a/src/schema.js
+++ b/src/schema.js
@@ -17,6 +17,12 @@ const createSchema = Joi =>
     outputDir: Joi.string()
       .default(DEFAULTS.outputDir)
       .description("The directory where the index file will be stored."),
+    theme: Joi.string()
+      .valid("basic", "dark", null)
+      .default("basic")
+      .description(
+        "The name of the Stork theme to install. Can be `null` to skip installing a theme."
+      ),
   });
 
 module.exports = { createSchema };


### PR DESCRIPTION
Allowing sites to automatically retrieve a theme from the Stork CDN will make this plugin much more plug-and-play, so this adds a config that lets users automatically fetch the Stork CSS file without having to manually append it to their HTML files.